### PR TITLE
Added swap_buffers through SDL_GL_SwapBuffers

### DIFF
--- a/ll.rs
+++ b/ll.rs
@@ -477,5 +477,6 @@ pub mod video {
         fn SDL_FillRect(dst: *SDL_Surface, dstrect: *Rect, color: uint32_t) -> c_int;
         fn SDL_LockSurface(surface: *SDL_Surface) -> c_int;
         fn SDL_UnlockSurface(surface: *SDL_Surface) -> c_int;
+        fn SDL_GL_SwapBuffers();
     }
 }

--- a/video.rs
+++ b/video.rs
@@ -147,3 +147,7 @@ pub fn create_rgb_surface(
         Ok(~Surface{ raw_surface: raw_surface })
     }
 }
+
+pub fn swap_buffers() {
+    ll::video::SDL_GL_SwapBuffers();
+}


### PR DESCRIPTION
Added support for SDL_GL_SwapBuffers with the function SDL::video::swap_buffers. This makes it possible to use OpenGL with doublebuffering.
