### PR TITLE
Wrap calls to low-level functions in unsafe { ... } blocks for language changes

### DIFF
--- a/sdl.rs
+++ b/sdl.rs
@@ -36,48 +36,59 @@ pub enum ErrorFlag {
 }
 
 pub fn init(flags: &[InitFlag]) -> bool {
-    (ll::sdl::SDL::SDL_Init(init_flags_to_bitfield(flags)) == 0 as c_int)
+    unsafe {
+        (ll::sdl::SDL::SDL_Init(init_flags_to_bitfield(flags)) == 0 as c_int)
+    }
 }
 
 pub fn init_subsystem(flags: &[InitFlag]) -> bool {
-    (ll::sdl::SDL::SDL_InitSubSystem(init_flags_to_bitfield(flags)) == 0 as c_int)
+    unsafe {
+        (ll::sdl::SDL::SDL_InitSubSystem(init_flags_to_bitfield(flags)) == 0 as c_int)
+    }
 }
 
 pub fn quit_subsystem(flags: &[InitFlag]) {
-    ll::sdl::SDL::SDL_QuitSubSystem(init_flags_to_bitfield(flags))
+    unsafe {
+        ll::sdl::SDL::SDL_QuitSubSystem(init_flags_to_bitfield(flags))
+    }
 }
 
 pub fn quit() {
-    ll::sdl::SDL::SDL_Quit()
+    unsafe {
+        ll::sdl::SDL::SDL_Quit()
+    }
 }
 
 pub fn was_init(flags: &[InitFlag]) -> ~[InitFlag] {
-    let bitflags = ll::sdl::SDL::SDL_WasInit(init_flags_to_bitfield(flags));
-    let all_flags = ~[
-        InitTimer,
-        InitAudio,
-        InitVideo,
-        InitCDRom,
-        InitJoystick,
-        InitHaptic,
-        InitNoParachute,
-        InitEventThread,
-    ];
-    
-    let mut vecflags = ~[];
+    unsafe {
+        let bitflags = ll::sdl::SDL::SDL_WasInit(init_flags_to_bitfield(flags));
+        let all_flags = ~[
+            InitTimer,
+            InitAudio,
+            InitVideo,
+            InitCDRom,
+            InitJoystick,
+            InitHaptic,
+            InitNoParachute,
+            InitEventThread,
+        ];
+        
+        let mut vecflags = ~[];
 
-    vec::map(all_flags, |flag| {
-        if bitflags & (*flag as ll::sdl::SDL_InitFlag) != 0 as ll::sdl::SDL_InitFlag {
-            push(&mut vecflags, *flag);
-        }
-    });
-    move vecflags
+        vec::map(all_flags, |flag| {
+            if bitflags & (*flag as ll::sdl::SDL_InitFlag) != 0 as ll::sdl::SDL_InitFlag {
+                push(&mut vecflags, *flag);
+            }
+        });
+        move vecflags
+    }
 }
 
 pub fn get_error() -> ~str {
-    let cstr = ll::error::SDL_GetError();
-    // FIXME: Converting sbuf to *c_char
     unsafe {
+        let cstr = ll::error::SDL_GetError();
+
+        // FIXME: Converting sbuf to *c_char
         let cstr = cast::reinterpret_cast(&cstr);
         str::raw::from_c_str(cstr)
     }
@@ -85,16 +96,22 @@ pub fn get_error() -> ~str {
 
 pub fn set_error(s: &str) {
     str::as_buf(s, |buf, _len| {
-        // FIXME: Converting sbuf to *c_char
-        let buf = unsafe { cast::reinterpret_cast(&buf) };
-        ll::error::SDL_SetError(buf)
+        unsafe {
+            // FIXME: Converting sbuf to *c_char
+            let buf = cast::reinterpret_cast(&buf);
+            ll::error::SDL_SetError(buf)
+        }
     });
 }
 
 pub fn error(code: ErrorFlag) {
-    ll::error::SDL_Error(code as ll::error::SDL_errorcode)
+    unsafe {
+        ll::error::SDL_Error(code as ll::error::SDL_errorcode)
+    }
 }
 
 pub fn clear_error() {
-    ll::error::SDL_ClearError()
+    unsafe {
+        ll::error::SDL_ClearError()
+    }
 }

--- a/video.rs
+++ b/video.rs
@@ -32,16 +32,20 @@ pub struct Surface {
 
 pub impl Surface {
     fn display_format(&self) -> Result<~Surface, ~str> {
-        let raw_surface = ll::video::SDL_DisplayFormat(self.raw_surface);
-        if raw_surface == ptr::null() {
-            Err(sdl::get_error())
-        } else {
-            Ok(~Surface{ raw_surface: raw_surface })
+        unsafe {
+            let raw_surface = ll::video::SDL_DisplayFormat(self.raw_surface);
+            if raw_surface == ptr::null() {
+                Err(sdl::get_error())
+            } else {
+                Ok(~Surface{ raw_surface: raw_surface })
+            }
         }
     }
 
     fn flip(&self) -> bool {
-        ll::video::SDL_Flip(self.raw_surface) == 0 as c_int
+        unsafe {
+            ll::video::SDL_Flip(self.raw_surface) == 0 as c_int
+        }
     }
 
     /// Locks a surface so that the pixels can be directly accessed safely.
@@ -57,35 +61,55 @@ pub impl Surface {
     }
 
     fn lock(&self) -> bool {
-        return ll::video::SDL_LockSurface(self.raw_surface) == 0 as c_int;
+        unsafe {
+            return ll::video::SDL_LockSurface(self.raw_surface) == 0 as c_int;
+        }
     }
 
     fn unlock(&self) -> bool {
-        return ll::video::SDL_UnlockSurface(self.raw_surface) == 0 as c_int;
+        unsafe {
+            return ll::video::SDL_UnlockSurface(self.raw_surface) == 0 as c_int;
+        }
     }
 
     fn blit_surface_rect(&self, src: &Surface, srcrect: &Rect, dstrect: &Rect) -> bool {
-        let res = ll::video::SDL_UpperBlit(src.raw_surface, srcrect, self.raw_surface, dstrect);
-        return res == 0 as c_int;
+        unsafe {
+            let res = ll::video::SDL_UpperBlit(src.raw_surface,
+                                               srcrect,
+                                               self.raw_surface,
+                                               dstrect);
+            return res == 0 as c_int;
+        }
     }
 
     fn blit_surface(&self, src: &Surface) -> bool {
-        let res = ll::video::SDL_UpperBlit(src.raw_surface, ptr::null(), self.raw_surface, ptr::null());
-        return res == 0 as c_int;
+        unsafe {
+            let res = ll::video::SDL_UpperBlit(src.raw_surface,
+                                               ptr::null(),
+                                               self.raw_surface,
+                                               ptr::null());
+            return res == 0 as c_int;
+        }
     }
 
     fn fill_rect(&self, rect: &Rect, color: u32) -> bool {
-        return ll::video::SDL_FillRect(self.raw_surface, rect, color) == 0 as c_int;
+        unsafe {
+            return ll::video::SDL_FillRect(self.raw_surface, rect, color) == 0 as c_int;
+        }
     }
 
     fn fill(&self, color: u32) -> bool {
-        return ll::video::SDL_FillRect(self.raw_surface, ptr::null(), color) == 0 as c_int;
+        unsafe {
+            return ll::video::SDL_FillRect(self.raw_surface, ptr::null(), color) == 0 as c_int;
+        }
     }
 }
 
 pub impl Surface : Drop {
     pub fn finalize(&self) {
-        ll::video::SDL_FreeSurface(self.raw_surface)
+        unsafe {
+            ll::video::SDL_FreeSurface(self.raw_surface)
+        }
     }
 }
 
@@ -105,12 +129,17 @@ pub fn set_video_mode(
         flags | *flag as u32
     });
 
-    let raw_surface = ll::video::SDL_SetVideoMode(width as c_int, height as c_int, bitsperpixel as c_int, flags);
+    unsafe {
+        let raw_surface = ll::video::SDL_SetVideoMode(width as c_int,
+                                                      height as c_int,
+                                                      bitsperpixel as c_int,
+                                                      flags);
 
-    if raw_surface == ptr::null() {
-        Err(sdl::get_error())
-    } else {
-        Ok(~Surface{ raw_surface: raw_surface })
+        if raw_surface == ptr::null() {
+            Err(sdl::get_error())
+        } else {
+            Ok(~Surface{ raw_surface: raw_surface })
+        }
     }
 }
 
@@ -120,14 +149,15 @@ pub fn load_bmp(file: &str) -> Result<~Surface, ~str> {
             cast::reinterpret_cast(&buf)
         };
         str::as_buf(~"rb", |rbbuf, _len| {
-            let rbbuf = unsafe {
-                cast::reinterpret_cast(&rbbuf)
-            };
-            let raw_surface = ll::video::SDL_LoadBMP_RW(ll::video::SDL_RWFromFile(buf, rbbuf), 1 as c_int);
-            if raw_surface == ptr::null() {
-                Err(sdl::get_error())
-            } else {
-                Ok(~Surface{ raw_surface: raw_surface })
+            unsafe {
+                let rbbuf = cast::reinterpret_cast(&rbbuf);
+                let raw_bmp = ll::video::SDL_RWFromFile(buf, rbbuf);
+                let raw_surface = ll::video::SDL_LoadBMP_RW(raw_bmp, 1 as c_int);
+                if raw_surface == ptr::null() {
+                    Err(sdl::get_error())
+                } else {
+                    Ok(~Surface{ raw_surface: raw_surface })
+                }
             }
         })
     })
@@ -142,16 +172,20 @@ pub fn create_rgb_surface(
         flags | *flag as u32
     });
 
-    let raw_surface = ll::video::SDL_CreateRGBSurface(
-        flags, width as c_int, height as c_int, bits_per_pixel as c_int,
-        rmask, gmask, bmask, amask);
-    if raw_surface == ptr::null() {
-        Err(sdl::get_error())
-    } else {
-        Ok(~Surface{ raw_surface: raw_surface })
+    unsafe {
+        let raw_surface = ll::video::SDL_CreateRGBSurface(
+            flags, width as c_int, height as c_int, bits_per_pixel as c_int,
+            rmask, gmask, bmask, amask);
+        if raw_surface == ptr::null() {
+            Err(sdl::get_error())
+        } else {
+            Ok(~Surface{ raw_surface: raw_surface })
+        }
     }
 }
 
 pub fn swap_buffers() {
-    ll::video::SDL_GL_SwapBuffers();
+    unsafe {
+        ll::video::SDL_GL_SwapBuffers();
+    }
 }


### PR DESCRIPTION
C functions are now implicitly unsafe per a language change on incoming. This fixes up rust-sdl for it.
