### PR TITLE
Add support for the SDL mixer.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,7 +1,7 @@
 VPATH=%VPATH%
 
 RUSTC ?= rustc
-RUSTFLAGS ?=
+RUSTFLAGS ?= --cfg mixer
 SDL_PREFIX ?= /usr/local/lib
 AR ?= ar
 CHMOD ?= chmod

--- a/audio.rs
+++ b/audio.rs
@@ -1,0 +1,35 @@
+use ll::audio::{AUDIO_S16LSB, AUDIO_S16MSB, AUDIO_S8, AUDIO_U16LSB, AUDIO_U16MSB, AUDIO_U8};
+
+pub enum AudioFormat {
+    U8AudioFormat,
+    S8AudioFormat,
+    U16LsbAudioFormat,
+    S16LsbAudioFormat,
+    U16MsbAudioFormat,
+    S16MsbAudioFormat,
+}
+
+impl AudioFormat {
+    fn to_ll_format(self) -> u16 {
+        match self {
+            U8AudioFormat => AUDIO_U8,
+            S8AudioFormat => AUDIO_S8,
+            U16LsbAudioFormat => AUDIO_U16LSB,
+            S16LsbAudioFormat => AUDIO_S16LSB,
+            U16MsbAudioFormat => AUDIO_U16MSB,
+            S16MsbAudioFormat => AUDIO_S16MSB,
+        }
+    }
+    static fn from_ll_format(x: u16) -> AudioFormat {
+        match x {
+            AUDIO_U8 => U8AudioFormat,
+            AUDIO_S8 => S8AudioFormat,
+            AUDIO_U16LSB => U16LsbAudioFormat,
+            AUDIO_S16LSB => S16LsbAudioFormat,
+            AUDIO_U16MSB => U16MsbAudioFormat,
+            AUDIO_S16MSB => S16MsbAudioFormat,
+            _ => die!(~"unexpected format")
+        }
+    }
+}
+

--- a/ll.rs
+++ b/ll.rs
@@ -490,3 +490,38 @@ pub mod video {
         fn SDL_GL_SwapBuffers();
     }
 }
+
+pub mod audio {
+    pub const AUDIO_U8: u16     = 0x0008;
+    pub const AUDIO_S8: u16     = 0x8008;
+    pub const AUDIO_U16LSB: u16 = 0x0010;
+    pub const AUDIO_S16LSB: u16 = 0x8010;
+    pub const AUDIO_U16MSB: u16 = 0x1010;
+    pub const AUDIO_S16MSB: u16 = 0x9010;
+    pub const AUDIO_U16: u16 = AUDIO_U16LSB;
+    pub const AUDIO_S16: u16 = AUDIO_S16LSB;
+}
+
+#[cfg(mixer)]
+pub mod mixer {
+    use core::libc::c_int;
+
+    pub struct Mix_Chunk {
+        allocated: c_int,
+        abuf: *u8,
+        alen: u32,
+        volume: u8,
+    }
+
+    #[link_args="-lSDL_mixer"]
+    extern {
+        fn Mix_OpenAudio(frequency: c_int, format: u16, channels: c_int, chunksize: c_int)
+                      -> c_int;
+        fn Mix_QuerySpec(frequency: *mut c_int, format: *mut u16, channels: *mut c_int) -> c_int;
+        fn Mix_PlayChannelTimed(channel: c_int, chunk: *Mix_Chunk, loops: c_int, ticks: c_int)
+                             -> c_int;
+        fn Mix_GetChunk(channel: c_int) -> *Mix_Chunk;
+        fn Mix_CloseAudio();
+    }
+}
+

--- a/mixer.rs
+++ b/mixer.rs
@@ -1,0 +1,96 @@
+use audio::AudioFormat;
+use ll::mixer::{Mix_Chunk, Mix_CloseAudio, Mix_GetChunk, Mix_OpenAudio, Mix_PlayChannelTimed};
+use ll::mixer::{Mix_QuerySpec};
+
+use core::cast::transmute;
+use core::libc::{c_int, malloc, size_t};
+
+pub struct Chunk {
+    buffer: ~[u8],
+    priv ll_chunk: Mix_Chunk
+}
+
+impl Drop for Chunk {
+    fn finalize(&self) {
+        unsafe {
+            // Verify that the chunk is not currently playing.
+            //
+            // TODO: I can't prove to myself that this is not racy, although I believe it is not
+            // as long as all SDL calls are happening from the same thread. Somebody with better
+            // knowledge of how SDL_mixer works internally should double check this, though.
+
+            let mut frequency = 0, format = 0, channels = 0;
+            if Mix_QuerySpec(&mut frequency, &mut format, &mut channels) == 0 {
+                channels = 0;
+            }
+
+            let ll_chunk_addr: *Mix_Chunk = &self.ll_chunk;
+            for uint::range(0, channels as uint) |ch| {
+                if Mix_GetChunk(ch as i32) == ll_chunk_addr {
+                    die!(~"attempt to free a channel that's playing!")
+                }
+            }
+        }
+    }
+}
+
+impl Chunk {
+    static pub fn new(buffer: ~[u8], volume: u8) -> Chunk {
+        unsafe {
+            let buffer_addr: *u8 = transmute(&buffer[0]);
+            let buffer_len = buffer.len() as u32;
+            Chunk {
+                buffer: buffer,
+                ll_chunk: Mix_Chunk {
+                    allocated: 0,
+                    abuf: buffer_addr,
+                    alen: buffer_len,
+                    volume: volume
+                }
+            }
+        }
+    }
+
+    fn volume(&self) -> u8 { self.ll_chunk.volume }
+
+    fn play_timed(&self, channel: Option<c_int>, loops: c_int, ticks: c_int) -> c_int {
+        unsafe {
+            let ll_channel = match channel {
+                None => -1,
+                Some(channel) => channel,
+            };
+            Mix_PlayChannelTimed(ll_channel, &self.ll_chunk, loops, ticks)
+        }
+    }
+
+    fn play(&self, channel: Option<c_int>, loops: c_int) -> c_int {
+        self.play_timed(channel, loops, -1)
+    }
+}
+
+pub enum Channels {
+    Mono,
+    Stereo,
+}
+
+impl Channels {
+    pub fn count(self) -> c_int { match self { Mono => 1, Stereo => 2 } }
+}
+
+pub fn open(frequency: c_int, format: AudioFormat, channels: Channels, chunksize: c_int)
+         -> Result<(),()> {
+    unsafe {
+        if Mix_OpenAudio(frequency, format.to_ll_format(), channels.count(), chunksize) == 0 {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+}
+
+pub fn close() {
+    unsafe {
+        Mix_CloseAudio()
+    }
+}
+

--- a/sdl.rc
+++ b/sdl.rc
@@ -16,7 +16,11 @@ pub mod util;
 pub mod event;
 pub mod video;
 pub mod keyboard;
+pub mod audio;
 pub mod start;
+
+#[cfg(mixer)]
+pub mod mixer;
 
 #[cfg(test)]
 mod test;


### PR DESCRIPTION
This is the only way to get audio support in Rust at the moment; the
low-level SDL_audio stuff wants to run a callback on a separate thread and that
will segfault at the moment. brson's stuff should eventually fix this, but for
now the SDL mixer must be used.
