### PR TITLE
Update pkg.rs

### DIFF
--- a/pkg.rs
+++ b/pkg.rs
@@ -1,3 +1,3 @@
 #[pkg(id = "org.brson.sdl",
       vers = "0.3.0")];
-#[pkg_crate(file = "sdl.rc")];
+#[pkg_crate(file = "src/sdl.rc")];


### PR DESCRIPTION
Seems like the initial support for rustpkg didn't account for the changed directory structure.
