### PR TITLE
Fixed obsolete syntax: visibility-qualified trait implementation

### DIFF
--- a/src/cd.rs
+++ b/src/cd.rs
@@ -125,7 +125,7 @@ pub impl CD {
 	}
 }
 
-pub impl Drop for CD {
+impl Drop for CD {
     pub fn finalize(&self) {
         unsafe { ll::SDL_CDClose(self.raw); }
     }

--- a/src/joy.rs
+++ b/src/joy.rs
@@ -110,7 +110,7 @@ pub impl Joystick {
 	}
 }
 
-pub impl Drop for Joystick {
+impl Drop for Joystick {
     pub fn finalize(&self) {
         unsafe { ll::SDL_JoystickClose(self.raw); }
     }

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -62,7 +62,7 @@ pub impl Cursor {
 	}
 }
 
-pub impl Drop for Cursor {
+impl Drop for Cursor {
     pub fn finalize(&self) {
         unsafe {
         	if self.owned {

--- a/src/video.rs
+++ b/src/video.rs
@@ -124,7 +124,7 @@ fn wrap_surface(raw: *ll::SDL_Surface, owned: bool) -> ~Surface {
     ~Surface{ raw: raw, owned: owned }
 }
 
-pub impl Drop for Surface {
+impl Drop for Surface {
     pub fn finalize(&self) {
         unsafe {
             if self.owned {
@@ -199,7 +199,7 @@ pub enum Color {
     RGBA(u8, u8, u8, u8)
 }
 
-pub impl rand::Rand for Color {
+impl rand::Rand for Color {
     static fn rand(rng: rand::Rng) -> Color {
         if rng.gen() { RGBA(rng.gen(), rng.gen(), rng.gen(), rng.gen()) }
         else { RGB(rng.gen(), rng.gen(), rng.gen()) }


### PR DESCRIPTION
Note from rust:

`pub` or `priv` is meaningless for trait implementations, because the `impl...for...` form defines overloads for methods that already exist; remove the `pub` or `priv`
