### PR TITLE
Explicitly prefix core modules with `core::` per upcoming language change

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -7,7 +7,7 @@ use core::libc::{c_int, c_void, uint16_t};
 use core::ptr::null;
 
 pub mod ll {
-    use libc::{c_int, c_void, uint16_t};
+    use core::libc::{c_int, c_void, uint16_t};
 
     pub const AUDIO_U8: uint16_t = 0x0008;
     pub const AUDIO_S8: uint16_t = 0x8008;

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -1,8 +1,9 @@
-use libc::c_int;
 use sdl;
 
+use core::libc::c_int;
+
 pub mod ll {
-	use libc::{c_int, c_schar, uint8_t, uint16_t, uint32_t};
+	use core::libc::{c_int, c_schar, uint8_t, uint16_t, uint32_t};
 
 	pub type CDstatus = c_int;
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,8 +1,9 @@
-use libc::c_int;
 use sdl;
 
+use core::libc::c_int;
+
 pub mod ll {
-    use libc::{c_void, c_int, c_uint, c_uchar, c_schar, uint8_t, uint16_t, int16_t};
+    use core::libc::{c_void, c_int, c_uint, c_uchar, c_schar, uint8_t, uint16_t, int16_t};
 
     pub type SDLKey = c_uint;
     pub type SDLMod = c_uint;

--- a/src/img.rs
+++ b/src/img.rs
@@ -1,10 +1,12 @@
-use video::Surface;
 use sdl;
-use libc::c_int;
+use video::Surface;
+
+use core::libc::c_int;
 
 pub mod ll {
-    use libc::{c_int, c_uint, c_schar};
     use video::ll::SDL_Surface;
+
+    use core::libc::{c_int, c_uint, c_schar};
 
     pub type IMG_InitFlags = c_uint;
 

--- a/src/joy.rs
+++ b/src/joy.rs
@@ -1,8 +1,9 @@
-use libc::c_int;
 use sdl;
 
+use core::libc::c_int;
+
 pub mod ll {
-	use libc::{c_void, c_int, c_schar, uint8_t, int16_t};
+	use core::libc::{c_void, c_int, c_schar, uint8_t, int16_t};
 
 	pub type SDL_Joystick = c_void;
 

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -1,9 +1,11 @@
-use libc::c_int;
 use sdl;
 
+use core::libc::c_int;
+
 pub mod ll {
-	use libc::{c_void, c_int, uint8_t, uint16_t, int16_t};
 	use sdl::Rect;
+
+	use core::libc::{c_void, c_int, uint8_t, uint16_t, int16_t};
 
 	pub const SDL_DISABLE: c_int = 0;
 	pub const SDL_ENABLE: c_int = 1;

--- a/src/sdl.rs
+++ b/src/sdl.rs
@@ -19,7 +19,7 @@ mod others {
 }
 
 pub mod ll {
-    use libc::{c_int, c_uint, c_schar, uint32_t};
+    use core::libc::{c_int, c_uint, c_schar, uint32_t};
 
     pub type SDL_errorcode = c_uint;
     pub const SDL_ENOMEM: SDL_errorcode = 0;

--- a/src/video.rs
+++ b/src/video.rs
@@ -1,12 +1,12 @@
-use libc::{c_int, c_float};
-use rand;
+use core::libc::{c_int, c_float};
+use core::rand;
 use sdl;
 use sdl::Rect;
 
 pub mod ll {
+    use core::libc::{c_void, c_uint, c_int, c_float, c_schar, c_uchar, uint8_t, uint16_t};
+    use core::libc::{uint32_t, int32_t};
     use sdl;
-    use libc::{c_void, c_uint, c_int, c_float, c_schar, c_uchar,
-               uint8_t, uint16_t, uint32_t, int32_t};
 
     pub type SDL_Rect = sdl::Rect;
 

--- a/src/wm.rs
+++ b/src/wm.rs
@@ -1,8 +1,9 @@
 use video;
 
 pub mod ll {
-	use libc::{c_schar, uint8_t, c_int};
 	use video::ll::SDL_Surface;
+
+	use core::libc::{c_schar, uint8_t, c_int};
 
 	pub type SDL_GrabMode = c_int;
 


### PR DESCRIPTION
This will soon be required in Rust (it's implemented in my branch) so I thought I'd update SDL ahead of time.
