### PR TITLE
Add mixer::Chunk::from_wav.

### DIFF
--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -1,9 +1,13 @@
 use audio::{AudioFormat, Channels, Mono, Stereo};
+use video::ll::SDL_RWFromFile; // XXX refactoring
+use sdl;
 
 use core::cast::transmute;
 use core::libc::{c_int, malloc, size_t};
 
 pub mod ll {
+    use video::ll::SDL_RWops; // XXX refactoring
+
     use core::libc::c_int;
 
     pub struct Mix_Chunk {
@@ -18,6 +22,8 @@ pub mod ll {
         fn Mix_OpenAudio(frequency: c_int, format: u16, channels: c_int, chunksize: c_int)
                       -> c_int;
         fn Mix_QuerySpec(frequency: *mut c_int, format: *mut u16, channels: *mut c_int) -> c_int;
+        fn Mix_LoadWAV_RW(src: *SDL_RWops, freesrc: c_int) -> *Mix_Chunk;
+        fn Mix_FreeChunk(chunk: *Mix_Chunk);
         fn Mix_AllocateChannels(numchans: c_int) -> c_int;
         fn Mix_Playing(channel: c_int) -> c_int;
         fn Mix_PlayChannelTimed(channel: c_int, chunk: *Mix_Chunk, loops: c_int, ticks: c_int)
@@ -29,52 +35,104 @@ pub mod ll {
 }
 
 pub struct Chunk {
+    priv data: ChunkData
+}
+
+enum ChunkData {
+    Borrowed(*ll::Mix_Chunk),
+    Allocated(*ll::Mix_Chunk),
+    OwnedBuffer(ChunkAndBuffer)
+}
+
+struct ChunkAndBuffer {
     buffer: ~[u8],
-    priv ll_chunk: ll::Mix_Chunk
+    ll_chunk: ll::Mix_Chunk
+}
+
+unsafe fn check_if_not_playing(ll_chunk_addr: *ll::Mix_Chunk) {
+    // Verify that the chunk is not currently playing.
+    //
+    // TODO: I can't prove to myself that this is not racy, although I believe it is not
+    // as long as all SDL calls are happening from the same thread. Somebody with better
+    // knowledge of how SDL_mixer works internally should double check this, though.
+
+    let mut frequency = 0, format = 0, channels = 0;
+    if ll::Mix_QuerySpec(&mut frequency, &mut format, &mut channels) == 0 {
+        channels = 0;
+    }
+
+    for uint::range(0, channels as uint) |ch| {
+        if ll::Mix_GetChunk(ch as i32) == ll_chunk_addr {
+            fail!(~"attempt to free a channel that's playing!")
+        }
+    }
 }
 
 impl Drop for Chunk {
     fn finalize(&self) {
         unsafe {
-            // Verify that the chunk is not currently playing.
-            //
-            // TODO: I can't prove to myself that this is not racy, although I believe it is not
-            // as long as all SDL calls are happening from the same thread. Somebody with better
-            // knowledge of how SDL_mixer works internally should double check this, though.
-
-            let mut frequency = 0, format = 0, channels = 0;
-            if ll::Mix_QuerySpec(&mut frequency, &mut format, &mut channels) == 0 {
-                channels = 0;
-            }
-
-            let ll_chunk_addr: *ll::Mix_Chunk = &self.ll_chunk;
-            for uint::range(0, channels as uint) |ch| {
-                if ll::Mix_GetChunk(ch as i32) == ll_chunk_addr {
-                    fail!(~"attempt to free a channel that's playing!")
+            match self.data {
+                Borrowed(_) => (),
+                Allocated(ll_chunk) => {
+                    check_if_not_playing(ll_chunk);
+                    ll::Mix_FreeChunk(ll_chunk);
+                },
+                OwnedBuffer(ref chunk) => {
+                    check_if_not_playing(&chunk.ll_chunk);
                 }
             }
         }
     }
 }
 
-impl Chunk {
-    static pub fn new(buffer: ~[u8], volume: u8) -> Chunk {
+pub impl Chunk {
+    static pub fn new(buffer: ~[u8], volume: u8) -> ~Chunk {
         unsafe {
             let buffer_addr: *u8 = transmute(&buffer[0]);
             let buffer_len = buffer.len() as u32;
-            Chunk {
-                buffer: buffer,
-                ll_chunk: ll::Mix_Chunk {
-                    allocated: 0,
-                    abuf: buffer_addr,
-                    alen: buffer_len,
-                    volume: volume
-                }
+            ~Chunk {
+                data: OwnedBuffer(
+                    ChunkAndBuffer {
+                        buffer: buffer,
+                        ll_chunk: ll::Mix_Chunk {
+                            allocated: 0,
+                            abuf: buffer_addr,
+                            alen: buffer_len,
+                            volume: volume
+                        }
+                    }
+                )
             }
         }
     }
 
-    fn volume(&self) -> u8 { self.ll_chunk.volume }
+    static fn from_wav(path: &Path) -> Result<~Chunk, ~str> {
+        let raw = unsafe {
+            do str::as_c_str(path.to_str()) |buf| {
+                do str::as_c_str("rb") |mode_buf| {
+                    ll::Mix_LoadWAV_RW(SDL_RWFromFile(buf, mode_buf), 1)
+                }
+            }
+        };
+
+        if raw.is_null() { Err(sdl::get_error()) }
+        else { Ok(~Chunk { data: Allocated(raw) }) }
+    }
+
+    fn to_ll_chunk(&self) -> *ll::Mix_Chunk {
+        match self.data {
+            Borrowed(ll_chunk) => ll_chunk,
+            Allocated(ll_chunk) => ll_chunk,
+            OwnedBuffer(ref chunk) => {
+                let ll_chunk: *ll::Mix_Chunk = &chunk.ll_chunk; ll_chunk
+            }
+        }
+    }
+
+    fn volume(&self) -> u8 {
+        let ll_chunk: *ll::Mix_Chunk = self.to_ll_chunk();
+        unsafe { (*ll_chunk).volume }
+    }
 
     fn play_timed(&self, channel: Option<c_int>, loops: c_int, ticks: c_int) -> c_int {
         unsafe {
@@ -82,7 +140,7 @@ impl Chunk {
                 None => -1,
                 Some(channel) => channel,
             };
-            ll::Mix_PlayChannelTimed(ll_channel, &self.ll_chunk, loops, ticks)
+            ll::Mix_PlayChannelTimed(ll_channel, self.to_ll_chunk(), loops, ticks)
         }
     }
 


### PR DESCRIPTION
This is a bit involved patch, since there are now two different chunk representations (one allocated/borrowed from SDL functions, one owned directly by Rust).

A side effect is that `Chunk` fields are no longer accessible from outside, which is actually desirable as updating the buffer while it is being played is not good. I guess we can add an accessor to `alen` however, which should be in another PR.
