### PR TITLE
Keep up with recent visibility changes in Rust

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -30,7 +30,7 @@ pub mod ll {
         userdata: *c_void,
     }
 
-    extern {
+    pub extern {
         pub fn SDL_OpenAudio(desired: *mut SDL_AudioSpec, obtained: *mut SDL_AudioSpec) -> c_int;
         pub fn SDL_PauseAudio(pause_on: c_int);
         pub fn SDL_MixAudio(dst: *mut u8, src: *u8, len: u32, volume: c_int);
@@ -52,7 +52,7 @@ pub enum AudioFormat {
 pub const U16AudioFormat: AudioFormat = U16LsbAudioFormat;
 pub const S16AudioFormat: AudioFormat = S16LsbAudioFormat;
 
-impl AudioFormat {
+pub impl AudioFormat {
     fn to_ll_format(self) -> uint16_t {
         match self {
             U8AudioFormat => AUDIO_U8,


### PR DESCRIPTION
Recent commit mozilla/rust@2e7ec80bcce454d55d31c6bd335bb2ad64a7298e added stronger visibility checks to Rust. This patch aligns with that change.
