### PR TITLE
Remove unused imports

### DIFF
--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -3,7 +3,7 @@ use video::ll::SDL_RWFromFile; // XXX refactoring
 use get_error;
 
 use core::cast::transmute;
-use core::libc::{c_int, malloc, size_t};
+use core::libc::{c_int};
 
 pub mod ll {
     use video::ll::SDL_RWops; // XXX refactoring

--- a/src/start.rs
+++ b/src/start.rs
@@ -1,8 +1,5 @@
-use core::cast::transmute;
 use core::cell::Cell;
-use core::libc::{c_char, c_int};
 use core::task::PlatformThread;
-use core::task::local_data;
 use core::task;
 
 type MainFunction = ~fn();


### PR DESCRIPTION
Just silencing some warnings:

```
robn@pyro:~/code/rust/rust-sdl$ make
rustc --cfg image --cfg mixer src/sdl.rc -o libsdl.dummy
src/start.rs:5:4: 5:27 warning: unused import
src/start.rs:5 use core::task::local_data;
                   ^~~~~~~~~~~~~~~~~~~~~~~
src/start.rs:3:17: 3:24 warning: unused import
src/start.rs:3 use core::libc::{c_char, c_int};
                                ^~~~~~~
src/start.rs:1:4: 1:26 warning: unused import
src/start.rs:1 use core::cast::transmute;
                   ^~~~~~~~~~~~~~~~~~~~~~
src/start.rs:3:25: 3:31 warning: unused import
src/start.rs:3 use core::libc::{c_char, c_int};
                                        ^~~~~~
src/mixer.rs:6:24: 6:31 warning: unused import
src/mixer.rs:6 use core::libc::{c_int, malloc, size_t};
                                       ^~~~~~~
src/mixer.rs:6:32: 6:39 warning: unused import
src/mixer.rs:6 use core::libc::{c_int, malloc, size_t};
                                               ^~~~~~~
touch libsdl.dummy
```
