### PR TITLE
Expose SDL GL support functions

### DIFF
--- a/src/gl.rs
+++ b/src/gl.rs
@@ -1,0 +1,42 @@
+use core::libc::{c_int};
+
+pub mod ll {
+    use core::libc::{c_int};
+
+    pub extern "C" {
+        fn SDL_GL_SetAttribute(attr: c_int, value: c_int) -> c_int;
+        fn SDL_GL_SwapBuffers();
+    }
+}
+
+pub enum GLAttribute {
+    RedSize = 0,
+    GreenSize,
+    BlueSize,
+    AlphaSize,
+    BufferSize,
+    DoubleBuffer,
+    DepthSize,
+    StencilSize,
+    AccumRedSize,
+    AccumGreenSize,
+    AccumBlueSize,
+    AccumAlphaSize,
+    Stereo,
+    MultiSampleBuffers,
+    MultiSampleSamples,
+    AcceleratedVisual,
+    SwapControl
+}
+
+pub fn set_attribute(attr: GLAttribute, value: int) -> int {
+    unsafe {
+        ll::SDL_GL_SetAttribute(attr as c_int, value as c_int) as int
+    }
+}
+
+pub fn swap_buffers() {
+    unsafe {
+        ll::SDL_GL_SwapBuffers();
+    }
+}

--- a/src/sdl.rc
+++ b/src/sdl.rc
@@ -20,6 +20,7 @@ pub mod joy;
 pub mod mouse;
 pub mod start;
 pub mod video;
+pub mod gl;
 pub mod wm;
 
 #[cfg(image)]


### PR DESCRIPTION
Exposes `SDL_GL_SetAttribute`, `SDL_GL_GetAttribute` and `SDL_GL_SwapBuffers`.

`get_attribute` segfaults on my system. I haven't been able to figure out why, after a lot of debugging and experimenting. As far as I can tell it looks like similar code. I figure one of you fine folks will understand the problem, but if not we could just not include it - the function itself is almost useless because it only queries SDL's internal state, not the underlying GL state. Even SDL's own documentation says not to bother with it.
