### PR TITLE
Port over to latest incoming

### DIFF
--- a/demo/video.rs
+++ b/demo/video.rs
@@ -28,11 +28,11 @@ pub fn main() {
 
 		screen.flip();
 
-		loop main: {
-			loop event: {
+		'main : loop {
+			'event : loop {
 				match sdl::event::poll_event() {
-					sdl::event::QuitEvent => break main,
-					sdl::event::NoEvent => break event,
+					sdl::event::QuitEvent => break 'main,
+					sdl::event::NoEvent => break 'event,
 					_ => {}
 				}
 			}

--- a/src/cd.rs
+++ b/src/cd.rs
@@ -55,7 +55,7 @@ pub fn get_drive_name(index: int) -> ~str {
 	unsafe {
 		let cstr = ll::SDL_CDName(index as c_int);
 
-		str::raw::from_c_str(cast::reinterpret_cast(&cstr))
+		str::raw::from_c_str(cast::transmute_copy(&cstr))
 	}
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -115,59 +115,59 @@ pub mod ll {
 
     pub impl SDL_Event {
         pub fn _type(&self) -> *uint8_t {
-            unsafe { cast::reinterpret_cast(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
         }
 
         pub fn active(&self) -> *SDL_ActiveEvent {
-            unsafe { cast::reinterpret_cast(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
         }
 
         pub fn key(&self) -> *SDL_KeyboardEvent {
-            unsafe { cast::reinterpret_cast(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
         }
 
         pub fn motion(&self) -> *SDL_MouseMotionEvent {
-            unsafe { cast::reinterpret_cast(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
         }
 
         pub fn button(&self) -> *SDL_MouseButtonEvent {
-            unsafe { cast::reinterpret_cast(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
         }
 
         pub fn jaxis(&self) -> *SDL_JoyAxisEvent {
-            unsafe { cast::reinterpret_cast(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
         }
 
         pub fn jball(&self) -> *SDL_JoyBallEvent {
-            unsafe { cast::reinterpret_cast(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
         }
 
         pub fn jhat(&self) -> *SDL_JoyHatEvent {
-            unsafe { cast::reinterpret_cast(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
         }
 
         pub fn jbutton(&self) -> *SDL_JoyButtonEvent {
-            unsafe { cast::reinterpret_cast(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
         }
 
         pub fn resize(&self) -> *SDL_ResizeEvent {
-            unsafe { cast::reinterpret_cast(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
         }
 
         pub fn expose(&self) -> *SDL_ExposeEvent {
-            unsafe { cast::reinterpret_cast(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
         }
 
         pub fn quit(&self) -> *SDL_QuitEvent {
-            unsafe { cast::reinterpret_cast(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
         }
 
         pub fn user(&self) -> *SDL_UserEvent {
-            unsafe { cast::reinterpret_cast(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
         }
 
         pub fn syswm(&self) -> *SDL_SysWMEvent {
-            unsafe { cast::reinterpret_cast(&ptr::to_unsafe_ptr(self)) }
+            unsafe { cast::transmute_copy(&ptr::to_unsafe_ptr(self)) }
         }
     }
 
@@ -717,7 +717,7 @@ pub fn pump_events() {
 
 pub fn wait_event() -> Event {
     let raw = null_event();
-    let success = unsafe { ll::SDL_WaitEvent(ptr::addr_of(&raw))
+    let success = unsafe { ll::SDL_WaitEvent(&raw)
                             == 1 as c_int };
 
     if success { wrap_event(raw) }
@@ -728,7 +728,7 @@ pub fn poll_event() -> Event {
     pump_events();
 
     let raw = null_event();
-    let have = unsafe { ll::SDL_PollEvent(ptr::addr_of(&raw)) };
+    let have = unsafe { ll::SDL_PollEvent(&raw) };
 
     if have != 1 {
         return NoEvent;
@@ -750,7 +750,7 @@ pub fn get_event_state(ty: EventType) -> bool {
 
 pub fn get_key_state() -> ~[(Key, bool)] {
     let num = 0;
-    let data = unsafe { ll::SDL_GetKeyState(ptr::addr_of(&num)) };
+    let data = unsafe { ll::SDL_GetKeyState(&num) };
     let mut i = -1;
 
     unsafe {
@@ -781,7 +781,7 @@ pub fn get_key_name(key: Key) -> ~str {
     unsafe {
         let cstr = ll::SDL_GetKeyName(key as ll::SDLKey);
 
-        str::raw::from_c_str(cast::reinterpret_cast(&cstr))
+        str::raw::from_c_str(cast::transmute_copy(&cstr))
     }
 }
 

--- a/src/img.rs
+++ b/src/img.rs
@@ -48,7 +48,7 @@ pub fn init(flags: &[InitFlag]) -> ~[InitFlag] {
 pub fn load(file: &Path) -> Result<~Surface, ~str> {
     str::as_buf(file.to_str(), |buf, _len| {
         let file = unsafe {
-            cast::reinterpret_cast(&buf)
+            cast::transmute_copy(&buf)
         };
 
         unsafe {

--- a/src/joy.rs
+++ b/src/joy.rs
@@ -36,7 +36,7 @@ pub fn get_joystick_name(index: int) -> ~str {
 	unsafe {
 		let cstr = ll::SDL_JoystickName(index as c_int);
 
-		str::raw::from_c_str(cast::reinterpret_cast(&cstr))
+		str::raw::from_c_str(cast::transmute_copy(&cstr))
 	}
 }
 
@@ -104,8 +104,8 @@ pub impl Joystick {
 		let dy = 0;
 
 		unsafe { ll::SDL_JoystickGetBall(self.raw, ball as c_int,
-			                             ptr::addr_of(&dx),
-			                             ptr::addr_of(&dy)); }
+			                             &dx,
+			                             &dy); }
 
 		(dx as int, dy as int)
 	}

--- a/src/sdl.rs
+++ b/src/sdl.rs
@@ -148,7 +148,7 @@ pub fn get_error() -> ~str {
     unsafe {
         let cstr = ll::SDL_GetError();
 
-        str::raw::from_c_str(cast::reinterpret_cast(&cstr))
+        str::raw::from_c_str(cast::transmute_copy(&cstr))
     }
 }
 

--- a/src/wm.rs
+++ b/src/wm.rs
@@ -42,11 +42,11 @@ pub fn get_caption() -> (~str, ~str) {
 	let icon_buf = ptr::null();
 
 	unsafe {
-		ll::SDL_WM_GetCaption(ptr::addr_of(&title_buf),
-			                  ptr::addr_of(&icon_buf));
+		ll::SDL_WM_GetCaption(&title_buf,
+			                  &icon_buf);
 
-        (str::raw::from_c_str(cast::reinterpret_cast(&title_buf)),
-         str::raw::from_c_str(cast::reinterpret_cast(&icon_buf)))
+        (str::raw::from_c_str(cast::transmute_copy(&title_buf)),
+         str::raw::from_c_str(cast::transmute_copy(&icon_buf)))
     }
 }
 


### PR DESCRIPTION
The changes were fairly mechanical, and not too big. Mostly reinterpret_cast was
replaced with transmute_copy, and ptr::addr_of was removed. However, a clumsy
workaround had to be made to return a borrowed pointer to an SDL_Palette, as
an unsafe pointer. That code is probable buggy anyways but the fix should be
reserved for a later date.
