### PR TITLE
fix c string casting

### DIFF
--- a/src/sdl.rs
+++ b/src/sdl.rs
@@ -158,7 +158,7 @@ pub fn get_error() -> ~str {
 }
 
 pub fn set_error(err: &str) {
-    do str::as_c_str(err) |buf| {
+    do err.as_c_str |buf| {
         unsafe { ll::SDL_SetError(buf); }
     }
 }

--- a/src/video.rs
+++ b/src/video.rs
@@ -492,8 +492,8 @@ impl Surface {
 
     pub fn from_bmp(path: &Path) -> Result<~Surface, ~str> {
         let raw = unsafe {
-            do str::as_c_str(path.to_str()) |buf| {
-                do str::as_c_str("rb") |mode_buf| {
+            do path.to_str().as_c_str |buf| {
+                do "rb".as_c_str |mode_buf| {
                     ll::SDL_LoadBMP_RW(ll::SDL_RWFromFile(buf, mode_buf), 1)
                 }
             }
@@ -617,8 +617,8 @@ impl Surface {
 
     pub fn save_bmp(&self, path: &Path) -> bool {
         unsafe {
-            do str::as_c_str(path.to_str()) |buf| {
-                do str::as_c_str("wb") |mode_buf| {
+            do path.to_str().as_c_str |buf| {
+                do "wb".as_c_str |mode_buf| {
                     ll::SDL_SaveBMP_RW(self.raw, ll::SDL_RWFromFile(buf, mode_buf), 1) == 0
                 }
             }

--- a/src/wm.rs
+++ b/src/wm.rs
@@ -34,8 +34,8 @@ pub enum GrabMode {
 }
 
 pub fn set_caption(title: &str, icon: &str) {
-	do str::as_c_str(title) |title_buf| {
-		do str::as_c_str(icon) |icon_buf| {
+	do title.as_c_str |title_buf| {
+		do icon.as_c_str |icon_buf| {
 			unsafe { ll::SDL_WM_SetCaption(title_buf, icon_buf); }
 		}
 	}


### PR DESCRIPTION
Updates rust-sdl to match revision in the handling of C-like (nul terminated) strings.
