### PR TITLE
Switch from std::rand::RngUtil to std::rand::Rng.

### DIFF
--- a/demo/video.rs
+++ b/demo/video.rs
@@ -1,4 +1,4 @@
-use std::rand::RngUtil;
+use std::rand::Rng;
 use std::rand;
 
 use sdl;

--- a/src/video.rs
+++ b/src/video.rs
@@ -2,7 +2,7 @@ use std::cast;
 use std::libc::{c_int, c_float};
 use std::ptr;
 use std::rand;
-use std::rand::RngUtil;
+use std::rand::Rng;
 use std::vec;
 
 use Rect;


### PR DESCRIPTION
Due to Rust commit fb923c7d3f8b.

Fixes Issue #98.
