### PR TITLE
Shebang fixed for freebsd

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SRCDIR="$(cd $(dirname $0) && pwd)"
 


### PR DESCRIPTION
I've changed the shebang for a better flexible format. Now the configure work on freebsd also. Only sh is in /bin/ on all unix system.
