### PR TITLE
Make all file-handling functions/methods use to_c_str().with_ref().

### DIFF
--- a/src/img.rs
+++ b/src/img.rs
@@ -1,4 +1,3 @@
-use std::cast;
 use std::libc::c_int;
 use std::ptr;
 
@@ -65,11 +64,7 @@ pub fn init(flags: &[InitFlag]) -> ~[InitFlag] {
 }
 
 pub fn load(file: &Path) -> Result<~Surface, ~str> {
-    do file.to_str().as_imm_buf |buf, _len| {
-        let file = unsafe {
-            cast::transmute_copy(&buf)
-        };
-
+    do file.to_c_str().with_ref |file| {
         unsafe {
             let raw = ll::IMG_Load(file);
 

--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -125,9 +125,14 @@ impl Chunk {
     }
 
     pub fn from_wav(path: &Path) -> Result<~Chunk, ~str> {
-        let raw = unsafe {
-            ll::Mix_LoadWAV_RW(SDL_RWFromFile(path.to_c_str().unwrap(), "rb".to_c_str().unwrap()), 1)
-        };
+        let raw =
+            do path.to_c_str().with_ref |path| {
+                do "rb".to_c_str().with_ref |mode| {
+                    unsafe {
+                        ll::Mix_LoadWAV_RW(SDL_RWFromFile(path, mode), 1)
+                    }
+                }
+            };
 
         if raw.is_null() { Err(get_error()) }
         else { Ok(~Chunk { data: Allocated(raw) }) }

--- a/src/video.rs
+++ b/src/video.rs
@@ -481,9 +481,14 @@ impl Surface {
     }
 
     pub fn from_bmp(path: &Path) -> Result<~Surface, ~str> {
-        let raw = unsafe {
-            ll::SDL_LoadBMP_RW(ll::SDL_RWFromFile(path.to_c_str().unwrap(), "rb".to_c_str().unwrap()), 1)
-        };
+        let raw =
+            do path.to_c_str().with_ref |path| {
+                do "rb".to_c_str().with_ref |mode| {
+                    unsafe {
+                        ll::SDL_LoadBMP_RW(ll::SDL_RWFromFile(path, mode), 1)
+                    }
+                }
+            };
 
         if raw.is_null() { Err(get_error()) }
         else { Ok(wrap_surface(raw, true)) }
@@ -602,9 +607,13 @@ impl Surface {
     }
 
     pub fn save_bmp(&self, path: &Path) -> bool {
-		unsafe {
-        	ll::SDL_SaveBMP_RW(self.raw, ll::SDL_RWFromFile(path.to_c_str().unwrap(), "wb".to_c_str().unwrap()), 1) == 0
-		}
+        do path.to_c_str().with_ref |path| {
+            do "wb".to_c_str().with_ref |mode| {
+                unsafe {
+                    ll::SDL_SaveBMP_RW(self.raw, ll::SDL_RWFromFile(path, mode), 1) == 0
+                }
+            }
+        }
     }
 
     pub fn set_alpha(&self, flags: &[SurfaceFlag], alpha: u8) -> bool {


### PR DESCRIPTION
For `img::load`, `as_imm_buf()` was used without converting the string to a null-terminated string and it caused errors quite hard to reason (as it caused `get_error()` to trigger `!is_utf8()` assertion). For others, there are no functional changes but I updated them anyway for consistency.
