### PR TITLE
Stop insisting on `mac_framework` or `mac_dylib`.

### DIFF
--- a/src/sdl/img.rs
+++ b/src/sdl/img.rs
@@ -11,7 +11,7 @@ mod mac {
     #[link_args="-framework SDL_image"]
     extern {}
 
-    #[cfg(mac_dylib)]
+    #[cfg(not(mac_framework))]
     #[link_args="-lSDL_image"]
     extern {}
 }

--- a/src/sdl/mixer.rs
+++ b/src/sdl/mixer.rs
@@ -12,7 +12,7 @@ mod mac {
     #[link_args="-framework SDL_mixer"]
     extern {}
 
-    #[cfg(mac_dylib)]
+    #[cfg(not(mac_framework))]
     #[link_args="-lSDL_mixer"]
     extern {}
 }

--- a/src/sdl/sdl.rs
+++ b/src/sdl/sdl.rs
@@ -8,7 +8,7 @@ mod mac {
     #[link_args="-framework SDL"]
     extern {}
 
-    #[cfg(mac_dylib)]
+    #[cfg(not(mac_framework))]
     #[link_args="-lSDL"]
     extern {}
 }


### PR DESCRIPTION
This is no longer needed now that we have `#[cfg(not(...))]`.
Furthermore, they break `rustpkg` use on Mac.
