### PR TITLE
Moved away from link_args as the compiler no longer likes them

### DIFF
--- a/src/sdl/img.rs
+++ b/src/sdl/img.rs
@@ -8,17 +8,17 @@ use video::Surface;
 #[cfg(target_os="macos")]
 mod mac {
     #[cfg(mac_framework)]
-    #[link_args="-framework SDL_image"]
+    #[link(name="framework SDL_image")]
     extern {}
 
     #[cfg(not(mac_framework))]
-    #[link_args="-lSDL_image"]
+    #[link(name="SDL_image")]
     extern {}
 }
 
 #[cfg(not(target_os="macos"))]
 mod others {
-    #[link_args="-lSDL_image"]
+    #[link(name="SDL_image")]
     extern {}
 }
 

--- a/src/sdl/mixer.rs
+++ b/src/sdl/mixer.rs
@@ -9,17 +9,17 @@ use get_error;
 #[cfg(target_os="macos")]
 mod mac {
     #[cfg(mac_framework)]
-    #[link_args="-framework SDL_mixer"]
+    #[link(name="framework SDL_mixer")]
     extern {}
 
     #[cfg(not(mac_framework))]
-    #[link_args="-lSDL_mixer"]
+    #[link(name="SDL_mixer")]
     extern {}
 }
 
 #[cfg(not(target_os="macos"))]
 mod others {
-    #[link_args="-lSDL_mixer"]
+    #[link(name="SDL_mixer")]
     extern {}
 }
 

--- a/src/sdl/sdl.rs
+++ b/src/sdl/sdl.rs
@@ -5,17 +5,17 @@ use std::str;
 #[cfg(target_os="macos")]
 mod mac {
     #[cfg(mac_framework)]
-    #[link_args="-framework SDL"]
+    #[link(name="framework SDL")]
     extern {}
 
     #[cfg(not(mac_framework))]
-    #[link_args="-lSDL"]
+    #[link(name="SDL")]
     extern {}
 }
 
 #[cfg(not(target_os="macos"))]
 mod others {
-    #[link_args="-lSDL"]
+    #[link(name="SDL")]
     extern {}
 }
 


### PR DESCRIPTION
I've moved to the modern form of linking to external packages.
However, I've not got access to an OSX machine that can actually build Rust at the moment, so I'm not sure this will work if mac_framework is set.
Still, other than that it seems happy on my Linux box.
