### PR TITLE
Fixed warning on 32-bit

### DIFF
--- a/src/sdl/video.rs
+++ b/src/sdl/video.rs
@@ -352,14 +352,14 @@ pub enum SurfaceFlag {
 
 #[deriving(Eq, TotalEq)]
 pub enum VideoFlag {
-    AnyFormat = 0x10000000,
-    HWPalette = 0x20000000,
-    DoubleBuf = 0x40000000,
-    Fullscreen = 0x80000000,
-    OpenGL = 0x00000002,
-    OpenGLBlit = 0x0000000A,
-    Resizable = 0x00000010,
-    NoFrame = 0x00000020
+    AnyFormat = 0x10000000u,
+    HWPalette = 0x20000000u,
+    DoubleBuf = 0x40000000u,
+    Fullscreen = 0x80000000u,
+    OpenGL = 0x00000002u,
+    OpenGLBlit = 0x0000000Au,
+    Resizable = 0x00000010u,
+    NoFrame = 0x00000020u
 }
 
 pub fn set_video_mode(w: int, h: int, bpp: int,


### PR DESCRIPTION
0x80000000 is not a positive number in on 32-bit, which issued a warning.
