### PR TITLE
Adds a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: build clean demo
+
+build:
+	rustc src/sdl/lib.rs
+
+clean:
+	rm *.rlib
+	rm demo
+
+demo:
+	rustc -o demo -L. src/sdl-demo/main.rs


### PR DESCRIPTION
Adds a Makefile with rules to build the rust-sdl library, build the demo
program, and clean up the built binaries.

Signed-off-by: zachwick zach@zachwick.com
