### PR TITLE
Add Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+
+name = "sdl"
+version = "0.8.0"
+authors = [ "brson" ]
+
+[[lib]]
+name = "sdl"
+path = "src/sdl/lib.rs"


### PR DESCRIPTION
For the Cargo package manager.

The package manager does not allow for more than one `[[lib]]` in `Cargo.toml`, so you'll have to figure something out for `sdl_image` and `sdl_mixer`. I'm guessing splitting them into separate repos is the way to go, but that's not my decision.

Also, I didn't know who should be included in `authors`, so I just put @brson for now
