### PR TITLE
added Cargo.toml for sdl_image and sdl_mixer

### DIFF
--- a/src/sdl_image/Cargo.toml
+++ b/src/sdl_image/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+
+name = "sdl_image"
+version = "0.3.4"
+authors = [ "brson" ]
+
+[[lib]]
+name = "sdl_image"
+path = "lib.rs"
+
+[dependencies.sdl]
+path = "../.."

--- a/src/sdl_mixer/Cargo.toml
+++ b/src/sdl_mixer/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+
+name = "sdl_mixer"
+version = "0.3.4"
+authors = [ "brson" ]
+
+[[lib]]
+name = "sdl_mixer"
+path = "lib.rs"
+
+[dependencies.sdl]
+path = "../.."


### PR DESCRIPTION
This is needed for Cargo to be able to automatically fetch those subpackages from the repo.
