### PR TITLE
added PatialOrd and Ord trait to event::Key enum

### DIFF
--- a/src/sdl/event.rs
+++ b/src/sdl/event.rs
@@ -225,7 +225,7 @@ pub enum RepeatInterval {
     CustomRepeatInterval(int)
 }
 
-#[deriving(PartialEq, Eq, FromPrimitive)]
+#[deriving(PartialEq, Eq, FromPrimitive, PartialOrd, Ord)]
 pub enum Key {
     UnknownKey = 0,
     BackspaceKey = 8,


### PR DESCRIPTION
Needed if you want to use Key as key in map.
