### PR TITLE
Replaced static declarations with const declarations

### DIFF
--- a/src/sdl/audio.rs
+++ b/src/sdl/audio.rs
@@ -11,14 +11,14 @@ pub mod ll {
 
     use libc::{c_int, c_void, uint16_t};
 
-    pub static AUDIO_U8: uint16_t = 0x0008;
-    pub static AUDIO_S8: uint16_t = 0x8008;
-    pub static AUDIO_U16LSB: uint16_t = 0x0010;
-    pub static AUDIO_S16LSB: uint16_t = 0x8010;
-    pub static AUDIO_U16MSB: uint16_t = 0x1010;
-    pub static AUDIO_S16MSB: uint16_t = 0x9010;
-    pub static AUDIO_U16: uint16_t = AUDIO_U16LSB;
-    pub static AUDIO_S16: uint16_t = AUDIO_S16LSB;
+    pub const AUDIO_U8: uint16_t = 0x0008;
+    pub const AUDIO_S8: uint16_t = 0x8008;
+    pub const AUDIO_U16LSB: uint16_t = 0x0010;
+    pub const AUDIO_S16LSB: uint16_t = 0x8010;
+    pub const AUDIO_U16MSB: uint16_t = 0x1010;
+    pub const AUDIO_S16MSB: uint16_t = 0x9010;
+    pub const AUDIO_U16: uint16_t = AUDIO_U16LSB;
+    pub const AUDIO_S16: uint16_t = AUDIO_S16LSB;
 
     #[repr(C)]
     pub struct SDL_AudioSpec {

--- a/src/sdl/cd.rs
+++ b/src/sdl/cd.rs
@@ -12,11 +12,11 @@ pub mod ll {
 
 	pub type CDstatus = c_int;
 
-	pub static CD_TRAYEMPTY: CDstatus = 0;
-	pub static CD_STOPPED: CDstatus = 1;
-	pub static CD_PLAYING: CDstatus = 2;
-	pub static CD_PAUSED: CDstatus = 3;
-	pub static CD_ERROR: CDstatus = -1;
+	pub const CD_TRAYEMPTY: CDstatus = 0;
+	pub const CD_STOPPED: CDstatus = 1;
+	pub const CD_PLAYING: CDstatus = 2;
+	pub const CD_PAUSED: CDstatus = 3;
+	pub const CD_ERROR: CDstatus = -1;
 
     #[repr(C)]
 	pub struct SDL_CDtrack {

--- a/src/sdl/event.rs
+++ b/src/sdl/event.rs
@@ -15,13 +15,13 @@ pub mod ll {
     pub type SDLMod = c_uint;
     pub type SDL_SysWMmsg = c_void;
 
-    pub static SDL_DISABLE: c_int = 0;
-    pub static SDL_ENABLE: c_int = 1;
-    pub static SDL_QUERY: c_int = -1;
+    pub const SDL_DISABLE: c_int = 0;
+    pub const SDL_ENABLE: c_int = 1;
+    pub const SDL_QUERY: c_int = -1;
 
-    pub static SDL_APPMOUSEFOCUS: c_int = 0x01;
-    pub static SDL_APPINPUTFOCUS: c_int = 0x02;
-    pub static SDL_APPACTIVE: c_int = 0x04;
+    pub const SDL_APPMOUSEFOCUS: c_int = 0x01;
+    pub const SDL_APPINPUTFOCUS: c_int = 0x02;
+    pub const SDL_APPACTIVE: c_int = 0x04;
 
     #[repr(C)]
     pub struct SDL_keysym {

--- a/src/sdl/sdl.rs
+++ b/src/sdl/sdl.rs
@@ -26,22 +26,22 @@ pub mod ll {
     use libc::types::os::arch::c95::c_schar;
 
     pub type SDL_errorcode = c_uint;
-    pub static SDL_ENOMEM: SDL_errorcode = 0;
-    pub static SDL_EFREAD: SDL_errorcode = 1;
-    pub static SDL_EFWRITE: SDL_errorcode = 2;
-    pub static SDL_EFSEEK: SDL_errorcode = 3;
-    pub static SDL_UNSUPPORTED: SDL_errorcode = 4;
-    pub static SDL_LASTERROR: SDL_errorcode = 5;
+    pub const SDL_ENOMEM: SDL_errorcode = 0;
+    pub const SDL_EFREAD: SDL_errorcode = 1;
+    pub const SDL_EFWRITE: SDL_errorcode = 2;
+    pub const SDL_EFSEEK: SDL_errorcode = 3;
+    pub const SDL_UNSUPPORTED: SDL_errorcode = 4;
+    pub const SDL_LASTERROR: SDL_errorcode = 5;
 
     pub type SDL_InitFlag = uint32_t;
-    pub static SDL_INIT_TIMER: SDL_InitFlag = 0x00000001;
-    pub static SDL_INIT_AUDIO: SDL_InitFlag = 0x00000010;
-    pub static SDL_INIT_VIDEO: SDL_InitFlag = 0x00000020;
-    pub static SDL_INIT_CDROM: SDL_InitFlag = 0x00000100;
-    pub static SDL_INIT_JOYSTICK: SDL_InitFlag = 0x00000200;
-    pub static SDL_INIT_NOPARACHUTE: SDL_InitFlag = 0x00100000;
-    pub static SDL_INIT_EVENTTHREAD: SDL_InitFlag = 0x01000000;
-    pub static SDL_INIT_EVERYTHING: SDL_InitFlag = 0x0000FFFF;
+    pub const SDL_INIT_TIMER: SDL_InitFlag = 0x00000001;
+    pub const SDL_INIT_AUDIO: SDL_InitFlag = 0x00000010;
+    pub const SDL_INIT_VIDEO: SDL_InitFlag = 0x00000020;
+    pub const SDL_INIT_CDROM: SDL_InitFlag = 0x00000100;
+    pub const SDL_INIT_JOYSTICK: SDL_InitFlag = 0x00000200;
+    pub const SDL_INIT_NOPARACHUTE: SDL_InitFlag = 0x00100000;
+    pub const SDL_INIT_EVENTTHREAD: SDL_InitFlag = 0x01000000;
+    pub const SDL_INIT_EVERYTHING: SDL_InitFlag = 0x0000FFFF;
 
     extern "C" {
         pub fn SDL_ClearError();

--- a/src/sdl/wm.rs
+++ b/src/sdl/wm.rs
@@ -14,10 +14,10 @@ pub mod ll {
 
 	pub type SDL_GrabMode = c_int;
 
-	pub static SDL_GRAB_QUERY: SDL_GrabMode = -1;
-	pub static SDL_GRAB_OFF: SDL_GrabMode = 0;
-	pub static SDL_GRAB_ON: SDL_GrabMode = 1;
-	pub static SDL_GRAB_FULLSCREEN: SDL_GrabMode = 2;
+	pub const SDL_GRAB_QUERY: SDL_GrabMode = -1;
+	pub const SDL_GRAB_OFF: SDL_GrabMode = 0;
+	pub const SDL_GRAB_ON: SDL_GrabMode = 1;
+	pub const SDL_GRAB_FULLSCREEN: SDL_GrabMode = 2;
 
     extern "C" {
         pub fn SDL_WM_SetCaption(title: *const c_schar, icon: *const c_schar);


### PR DESCRIPTION
Version 0.12 of Rust has changed the restrictions on using static variables. I think this is related to [RFC_69](https://github.com/rust-lang/rfcs/blob/master/active/0069-const-vs-static.md). I've replaced all the static declarations in modules that wouldn't compile to now be constant declarations, and the library now seems to work fine with the current master branch of rust.
