### PR TITLE
fail -> panic

### DIFF
--- a/src/sdl-demo/main.rs
+++ b/src/sdl-demo/main.rs
@@ -12,7 +12,7 @@ pub fn main() {
     let screen = match sdl::video::set_video_mode(800, 600, 32, [sdl::video::HWSurface],
                                                                 [sdl::video::DoubleBuf]) {
         Ok(screen) => screen,
-        Err(err) => fail!("failed to set video mode: {}", err)
+        Err(err) => panic!("failed to set video mode: {}", err)
     };
 
     // Note: You'll want to put this and the flip call inside the main loop

--- a/src/sdl-demo/sdl_main.rs
+++ b/src/sdl-demo/sdl_main.rs
@@ -35,7 +35,7 @@ pub fn real_main() {
     let screen = match sdl::video::set_video_mode(800, 600, 32, [sdl::video::HWSurface],
                                                                 [sdl::video::DoubleBuf]) {
         Ok(screen) => screen,
-        Err(err) => fail!("failed to set video mode: {}", err)
+        Err(err) => panic!("failed to set video mode: {}", err)
     };
 
     // Note: You'll want to put this and the flip call inside the main loop

--- a/src/sdl/audio.rs
+++ b/src/sdl/audio.rs
@@ -75,7 +75,7 @@ impl AudioFormat {
             AUDIO_S16LSB => S16LsbAudioFormat,
             AUDIO_U16MSB => U16MsbAudioFormat,
             AUDIO_S16MSB => S16MsbAudioFormat,
-            _ => fail!("unexpected format")
+            _ => panic!("unexpected format")
         }
     }
 }

--- a/src/sdl/video.rs
+++ b/src/sdl/video.rs
@@ -563,7 +563,7 @@ impl Surface {
     /// Locks a surface so that the pixels can be directly accessed safely.
     pub fn with_lock<R>(&self, f: |&mut [u8]| -> R) -> R {
         unsafe {
-            if ll::SDL_LockSurface(self.raw) != 0 { fail!("could not lock surface"); }
+            if ll::SDL_LockSurface(self.raw) != 0 { panic!("could not lock surface"); }
             let len = (*self.raw).pitch as uint * ((*self.raw).h as uint);
             let pixels: &mut [u8] = mem::transmute(((*self.raw).pixels, len));
             let rv = f(pixels);

--- a/src/sdl_mixer/lib.rs
+++ b/src/sdl_mixer/lib.rs
@@ -88,7 +88,7 @@ unsafe fn check_if_not_playing(ll_chunk_addr: *mut ll::Mix_Chunk) {
 
     for ch in range(0, (channels as uint)) {
         if ll::Mix_GetChunk(ch as i32) == ll_chunk_addr {
-            fail!("attempt to free a channel that's playing!")
+            panic!("attempt to free a channel that's playing!")
         }
     }
 }


### PR DESCRIPTION
The `fail` macro was renamed to `panic`.
