### PR TITLE
Fix `sdl_main` demo due to librustrt -> std::rt

### DIFF
--- a/src/sdl-demo/sdl_main.rs
+++ b/src/sdl-demo/sdl_main.rs
@@ -20,8 +20,8 @@ use sdl::event::{Event, Key};
 
 #[no_mangle]
 #[allow(non_snake_case)]
-pub extern "C" fn SDL_main(argc: int, argv: *const *const u8) {
-    std::rt::start(argc, argv, real_main);
+pub extern "C" fn SDL_main() {
+    real_main()
 }
 
 pub fn real_main() {


### PR DESCRIPTION
This solution works (tested on OS X), however there may be a better way to do this (one that keeps argc & argv). As far as I can tell `std::rt:start` has been replaced with `std::rt:lang_start` which is now private.
