### PR TITLE
Fixes to deal with c_str / c_vec stabilization changes related to Rust R...

### DIFF
--- a/src/sdl/cd.rs
+++ b/src/sdl/cd.rs
@@ -1,5 +1,7 @@
 use std::mem;
 use libc::c_int;
+use std::str;
+use std::ffi;
 
 use get_error;
 
@@ -67,7 +69,7 @@ pub fn get_drive_name(index: int) -> String {
 	unsafe {
 		let cstr = ll::SDL_CDName(index as c_int);
 
-		String::from_raw_buf(mem::transmute_copy(&cstr))
+		str::from_utf8(ffi::c_str_to_bytes(mem::transmute_copy(&cstr))).to_string()
 	}
 }
 

--- a/src/sdl/event.rs
+++ b/src/sdl/event.rs
@@ -2,6 +2,8 @@ use std::mem;
 use libc::c_int;
 use std::slice;
 use std::num::FromPrimitive;
+use std::ffi;
+use std::str;
 
 pub mod ll {
     #![allow(non_camel_case_types)]
@@ -849,7 +851,7 @@ pub fn get_key_name(key: Key) -> String {
     unsafe {
         let cstr = ll::SDL_GetKeyName(key as ll::SDLKey);
 
-        String::from_raw_buf(mem::transmute_copy(&cstr))
+        str::from_utf8(ffi::c_str_to_bytes(mem::transmute_copy(&cstr))).to_string()
     }
 }
 

--- a/src/sdl/joy.rs
+++ b/src/sdl/joy.rs
@@ -1,5 +1,7 @@
 use std::mem;
 use libc::c_int;
+use std::ffi;
+use std::str;
 
 use get_error;
 
@@ -40,7 +42,7 @@ pub fn get_joystick_name(index: int) -> String {
 	unsafe {
 		let cstr = ll::SDL_JoystickName(index as c_int);
 
-		String::from_raw_buf(mem::transmute_copy(&cstr))
+		str::from_utf8(ffi::c_str_to_bytes(mem::transmute_copy(&cstr))).to_string()
 	}
 }
 

--- a/src/sdl/lib.rs
+++ b/src/sdl/lib.rs
@@ -1,5 +1,4 @@
-#![feature(globs)]
-#![allow(raw_pointer_deriving)]
+#![allow(raw_pointer_derive)]
 
 extern crate libc;
 extern crate rand;

--- a/src/sdl/sdl.rs
+++ b/src/sdl/sdl.rs
@@ -1,5 +1,7 @@
 use std::mem;
-use std::c_str::ToCStr;
+use std::ffi;
+use std::str;
+use std::ffi::CString;
 
 // Setup linking for all targets.
 #[cfg(target_os="macos")]
@@ -162,12 +164,12 @@ pub fn get_error() -> String {
     unsafe {
         let cstr = ll::SDL_GetError();
 
-        String::from_raw_buf(mem::transmute_copy(&cstr))
+        str::from_utf8(ffi::c_str_to_bytes(mem::transmute_copy(&cstr))).to_string()
     }
 }
 
 pub fn set_error(err: &str) {
-    unsafe { ll::SDL_SetError(err.to_c_str().into_inner()); }
+    unsafe { ll::SDL_SetError(CString::from_slice(err.as_bytes()).as_ptr()); }
 }
 
 pub fn set_error_from_code(err: Error) {

--- a/src/sdl/video.rs
+++ b/src/sdl/video.rs
@@ -3,7 +3,7 @@ use libc::{c_int, c_float};
 use std::ptr;
 use rand::Rng;
 use std::slice;
-use std::c_str::ToCStr;
+use std::ffi::CString;
 
 use Rect;
 use get_error;
@@ -211,7 +211,7 @@ impl Drop for Surface {
 }
 
 #[derive(PartialEq)]
-#[allow(raw_pointer_deriving)]
+#[allow(raw_pointer_derive)]
 pub struct Palette {
     pub raw: *mut ll::SDL_Palette
 }
@@ -513,8 +513,8 @@ impl Surface {
     }
 
     pub fn from_bmp(path: &Path) -> Result<Surface, String> {
-        let cpath = path.to_c_str();
-        let mode = "rb".to_c_str();
+        let cpath = CString::from_slice(path.as_vec());
+        let mode = CString::from_slice("rb".as_bytes());
         let raw = unsafe {
             ll::SDL_LoadBMP_RW(ll::SDL_RWFromFile(cpath.as_ptr(), mode.as_ptr()), 1)
         };
@@ -636,8 +636,8 @@ impl Surface {
     }
 
     pub fn save_bmp(&self, path: &Path) -> bool {
-        let cpath = path.to_c_str();
-        let mode = "wb".to_c_str();
+        let cpath = CString::from_slice(path.as_vec());
+        let mode = CString::from_slice("wb".as_bytes());
         unsafe {
             ll::SDL_SaveBMP_RW(self.raw, ll::SDL_RWFromFile(cpath.as_ptr(), mode.as_ptr()), 1) == 0
         }

--- a/src/sdl/wm.rs
+++ b/src/sdl/wm.rs
@@ -1,6 +1,8 @@
 use std::mem;
 use std::ptr;
-use std::c_str::ToCStr;
+use std::ffi;
+use std::str;
+use std::ffi::CString;
 
 use video;
 
@@ -39,7 +41,7 @@ pub enum GrabMode {
 impl Copy for GrabMode {}
 
 pub fn set_caption(title: &str, icon: &str) {
-	unsafe { ll::SDL_WM_SetCaption(title.to_c_str().into_inner(), icon.to_c_str().into_inner()); }
+	unsafe { ll::SDL_WM_SetCaption(CString::from_slice(title.as_bytes()).as_ptr(), CString::from_slice(icon.as_bytes()).as_ptr()); }
 }
 
 pub fn get_caption() -> (String, String) {
@@ -50,8 +52,8 @@ pub fn get_caption() -> (String, String) {
 		ll::SDL_WM_GetCaption(&mut title_buf,
 			                  &mut icon_buf);
 
-        (String::from_raw_buf(mem::transmute_copy(&title_buf)),
-         String::from_raw_buf(mem::transmute_copy(&icon_buf)))
+        (str::from_utf8(ffi::c_str_to_bytes(mem::transmute_copy(&title_buf))).to_string(),
+         str::from_utf8(ffi::c_str_to_bytes(mem::transmute_copy(&icon_buf))).to_string())
     }
 }
 


### PR DESCRIPTION
...FC 494 now in the nightly.

This fixes a bunch of c_str related issues that popped up building against the latest nightly, which seem to be related to changes that got made as a result of RFC 494.

One thing I was not sure about was replacing the seemingly deprecated `into_inner` calls with `as_ptr`.  The behavior isn't the same IIRC - Rust wouldn't clean up the memory for the former.  That doesn't seem like correct behavior though, as the callee SDL methods are FFI calls into C methods that won't free the argument either.