### PR TITLE
Fixed sdl::get_error to not segfault

### DIFF
--- a/src/sdl/sdl.rs
+++ b/src/sdl/sdl.rs
@@ -162,9 +162,10 @@ pub fn was_inited(flags: &[InitFlag]) -> Vec<InitFlag> {
 
 pub fn get_error() -> String {
     unsafe {
-        let cstr = ll::SDL_GetError();
+        let cstr = ll::SDL_GetError() as *const i8;
+        let slice = ffi::c_str_to_bytes(&cstr);
 
-        str::from_utf8(ffi::c_str_to_bytes(mem::transmute_copy(&cstr))).unwrap().to_string()
+        str::from_utf8(slice).unwrap().to_string()
     }
 }
 


### PR DESCRIPTION
This one was a bit tricky as I am not sure what the initial version had tried
to do. `SDL_GetError()` returns a constant char pointer. (`char const *`)
However they are already in bytes. `c_str_to_bytes` expects a pointer to a
c_str as seen here: [Rust Source](1)

This version seems safer to me as we do not transmute, and since SDL explicitely
states that those strings are fixed in memory this should not segfault.

[1]: https://github.com/rust-lang/rust/blob/master/src/libstd/ffi/c_str.rs#L186