### PR TITLE
Handle SDL errors and fix segfaults

### DIFF
--- a/src/sdl/cd.rs
+++ b/src/sdl/cd.rs
@@ -1,4 +1,3 @@
-use std::mem;
 use libc::c_int;
 use std::str;
 use std::ffi::CStr;
@@ -63,11 +62,15 @@ pub fn get_num_drives() -> isize {
     unsafe { ll::SDL_CDNumDrives() as isize }
 }
 
-pub fn get_drive_name(index: isize) -> String {
+pub fn get_drive_name(index: isize) -> Result<String, String> {
     unsafe {
         let cstr = ll::SDL_CDName(index as c_int);
 
-        str::from_utf8(CStr::from_ptr(mem::transmute_copy(&cstr)).to_bytes()).unwrap().to_string()
+        if cstr.is_null() {
+            Err(get_error())
+        } else {
+            Ok(str::from_utf8(CStr::from_ptr(cstr).to_bytes()).unwrap().to_string())
+        }
     }
 }
 

--- a/src/sdl/joy.rs
+++ b/src/sdl/joy.rs
@@ -1,4 +1,3 @@
-use std::mem;
 use libc::c_int;
 use std::ffi::CStr;
 use std::str;
@@ -38,11 +37,15 @@ pub fn get_num_joysticks() -> isize {
     unsafe { ll::SDL_NumJoysticks() as isize }
 }
 
-pub fn get_joystick_name(index: isize) -> String {
+pub fn get_joystick_name(index: isize) -> Result<String, String> {
     unsafe {
         let cstr = ll::SDL_JoystickName(index as c_int);
 
-        str::from_utf8(CStr::from_ptr(mem::transmute_copy(&cstr)).to_bytes()).unwrap().to_string()
+        if cstr.is_null() {
+            Err(get_error())
+        } else {
+            Ok(str::from_utf8(CStr::from_ptr(cstr).to_bytes()).unwrap().to_string())
+        }
     }
 }
 

--- a/src/sdl/wm.rs
+++ b/src/sdl/wm.rs
@@ -47,16 +47,23 @@ pub fn set_caption(title: &str, icon: &str) {
 pub fn get_caption() -> (String, String) {
     let mut title_buf = ptr::null_mut();
     let mut icon_buf = ptr::null_mut();
+    let mut title = String::new();
+    let mut icon = String::new();
 
     unsafe {
-        ll::SDL_WM_GetCaption(&mut title_buf,
-                              &mut icon_buf);
+        ll::SDL_WM_GetCaption(&mut title_buf, &mut icon_buf);
 
-        let title_slice = CStr::from_ptr(mem::transmute_copy(&title_buf)).to_bytes();
-        let icon_slice = CStr::from_ptr(mem::transmute_copy(&icon_buf)).to_bytes();
+        if !title_buf.is_null() {
+            let slice = CStr::from_ptr(mem::transmute_copy(&mut &title_buf)).to_bytes();
+            title = str::from_utf8(slice).unwrap().to_string();
+        }
 
-        (str::from_utf8(title_slice).unwrap().to_string(),
-         str::from_utf8(icon_slice).unwrap().to_string())
+        if !icon_buf.is_null() {
+            let slice = CStr::from_ptr(mem::transmute_copy(&mut &icon_buf)).to_bytes();
+            icon = str::from_utf8(slice).unwrap().to_string();
+        }
+
+        (title, icon)
     }
 }
 


### PR DESCRIPTION
Submitting this one as a PR, it includes breaking changes to the existing API:

`get_drive_name` and `get_joystick_name` may call `SDL_SetError` so the return type of these functions was changed from `String` to `Restult<String, String>`.

If there is anything wrong with these changes or if you have better suggestions, let me know.