### PR TITLE
Update rand to 0.3 for latest rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ name = "sdl"
 path = "src/sdl/lib.rs"
 
 [dependencies]
-rand = "0.2"
+rand = "0.3"

--- a/src/sdl-demo/Cargo.toml
+++ b/src/sdl-demo/Cargo.toml
@@ -14,4 +14,4 @@ path = "main.rs"
 path = "../.."
 
 [dependencies]
-rand = "0.2"
+rand = "0.3"


### PR DESCRIPTION
Rust no longer compiles `rand 0.2`:

```
rand-0.2.1/src/distributions/range.rs:155:17: 155:44 error: type annotations required: cannot resolve `<f32 as core::ops::Add<_>>::Output == f32` [E0284]
```

But `rand 0.3.4` compiles and is working well with `rust-sdl`.

(Tested against `rustc 1.0.0-nightly (6cf3b0b74 2015-03-30) (built 2015-03-31)`)

This just bumps the `rand` version.
